### PR TITLE
add explicit next_version export in SYNOPSIS

### DIFF
--- a/lib/Version/Next.pm
+++ b/lib/Version/Next.pm
@@ -71,7 +71,7 @@ __END__
 
 = SYNOPSIS
 
-  use Version::Next;
+  use Version::Next qw/next_version/;
 
   my $new_version = next_version( $old_version );
 


### PR DESCRIPTION
I've added explicit `next_version` export to SYNOPSIS, because currently it's not a valid code snippet (in USAGE you write _This module uses Sub::Exporter for optional exporting. Nothing is exported by default_).
