### PR TITLE
use version::is_lax for string parsing

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires "Carp" => "0";
 requires "Sub::Exporter" => "0";
 requires "perl" => "5.006";
 requires "strict" => "0";
+requires "version" => "0.81";
 requires "warnings" => "0";
 
 on 'test' => sub {
@@ -10,7 +11,6 @@ on 'test' => sub {
   requires "List::Util" => "0";
   requires "Test::Exception" => "0.29";
   requires "Test::More" => "0.88";
-  requires "version" => "0";
 };
 
 on 'test' => sub {

--- a/lib/Version/Next.pm
+++ b/lib/Version/Next.pm
@@ -6,7 +6,7 @@ package Version::Next;
 # VERSION
 
 # Dependencies
-# use version 0.81 (); # XXX not out yet
+use version 0.81 ();
 use Carp ();
 
 # Exporting
@@ -16,9 +16,8 @@ sub next_version {
     my $version = shift;
     return 0 unless defined $version;
 
-    # XXX when next version.pm comes out, use version::is_lax
     Carp::croak("Doesn't look like a version number: '$version'")
-      unless $version =~ m{\Av?[0-9._]+\z};
+      unless version::is_lax($version);
 
     my $new_ver;
     my $num_dots =()= $version =~ /(\.)/g;

--- a/t/version-next.t
+++ b/t/version-next.t
@@ -14,8 +14,10 @@ can_ok( 'Version::Next', 'next_version' );
 eval "use Version::Next 'next_version'";
 can_ok( 'main', 'next_version' );
 is( next_version(1), 2, "1 + 1 == 2" );
-throws_ok { next_version('abc') } qr/Doesn't look like a version number: 'abc' at/,
-  "throws error on bad input";
+for my $error_case (qw( abc 1_00_01 1.00_ 1..0 v1_ )) {
+    throws_ok { next_version($error_case) } qr/Doesn't look like a version number: '$error_case' at/,
+      "throws error on bad input ($error_case)";
+}
 
 for my $case (<DATA>) {
     chomp $case;


### PR DESCRIPTION
(Continued from #2) 

I've found some TODO comments in code, and because version 0.81 was out (some time ago), I used `version::is_lax` for string parsing as you had intended.

(Copied [this comment](https://github.com/dagolden/Version-Next/pull/2#issuecomment-36899914).)

Using `version::is_lax` handles some invalid strings like `1_09_1` or `1._0_9` while your regexp returns true, and later Version::Next warns:

```
Argument "1._0_9" isn't numeric in addition (+) at /usr/local/perl514/lib/site_perl/5.14.2/Version/Next.pm line 69
```

when `version::is_lax('1_09_1')` returns false.

It seems `version::is_strict` does not handle dev versions, so `version::is_strict('1.01_01')` returns false.
